### PR TITLE
Cross-platform fixes, CI for Linux and MacOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,27 +31,28 @@ jobs:
           cd build
           ctest --output-on-failure
 
-  cpp-windows:
-    runs-on: windows-latest
-    steps:
-      # Install CMake
-      - name: Install CMake
-        run: |
-          choco install cmake
-      # Clone the repository
-      - uses: actions/checkout@v4
-      # CMake configure and build
-      - name: Build
-        run: |
-          mkdir build
-          cd build
-          cmake ..
-          cmake --build . --config Release
-      # Run tests
-      - name: Test
-        run: |
-          cd build
-          ctest --output-on-failure
+  # TODO(https://github.com/Verdant-Robotics/vlog/issues/3): Enable Windows CI
+  # cpp-windows:
+  #   runs-on: windows-latest
+  #   steps:
+  #     # Install CMake
+  #     - name: Install CMake
+  #       run: |
+  #         choco install cmake
+  #     # Clone the repository
+  #     - uses: actions/checkout@v4
+  #     # CMake configure and build
+  #     - name: Build
+  #       run: |
+  #         mkdir build
+  #         cd build
+  #         cmake ..
+  #         cmake --build . --config Release
+  #     # Run tests
+  #     - name: Test
+  #       run: |
+  #         cd build
+  #         ctest --output-on-failure
 
   cpp-macos:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Install CMake
-      - name: Install CMake
+      - name: Install CMake, libelf, libdwarf
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake
+          sudo apt-get install -y cmake libelf-dev libdwarf-dev
       # Clone the repository
       - uses: actions/checkout@v4
       # CMake configure and build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+    tags: ["releases/**"]
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  cpp-linux:
+    runs-on: ubuntu-latest
+    steps:
+      # Install CMake
+      - name: Install CMake
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake
+      # Clone the repository
+      - uses: actions/checkout@v4
+      # CMake configure and build
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+      # Run tests
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+
+  cpp-windows:
+    runs-on: windows-latest
+    steps:
+      # Install CMake
+      - name: Install CMake
+        run: |
+          choco install cmake
+      # Clone the repository
+      - uses: actions/checkout@v4
+      # CMake configure and build
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          cmake --build . --config Release
+      # Run tests
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+
+  cpp-macos:
+    runs-on: macos-latest
+    steps:
+      # Install CMake
+      - name: Install CMake
+        run: |
+          brew install cmake
+      # Clone the repository
+      - uses: actions/checkout@v4
+      # CMake configure and build
+      - name: Build
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+      # Run tests
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,11 @@ include(FetchDependency)
 # Have the stb susbsystem separate because it does not support all the warnings
 add_library(vlogstb STATIC stb/vlog_stbprint.cpp)
 target_include_directories(vlogstb SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/stb)
-target_compile_options(vlogstb PRIVATE -Wno-extra-semi-stmt
-  -Wno-conditional-uninitialized -Wno-implicit-fallthrough)
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR
+    "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+    target_compile_options(vlogstb PRIVATE
+        -Wno-extra-semi-stmt -Wno-conditional-uninitialized -Wno-implicit-fallthrough)
+endif()
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "14.0.0")
   # on new compiler version, we need to disable warning
   target_compile_options(vlogstb PRIVATE -Wno-reserved-identifier)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,17 @@ cmake_minimum_required(VERSION 3.13)
 
 project(vlog)
 
-# need to force so tests run outside of CI
+# Tests assume debug symbols are present
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build Type" FORCE)
 endif()
 
-option(ENABLE_BACKTRACE "Enable Backtrace Printing" TRUE)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  option(ENABLE_BACKTRACE "Enable Backtrace Printing" TRUE)
+else()
+  option(ENABLE_BACKTRACE "Enable Backtrace Printing" FALSE)
+endif()
+
 option(ENABLE_VLOG_TESTS "Enable VLog Tests" ON)
 
 set(VLOG_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
@@ -58,24 +63,23 @@ target_link_libraries(vlog PRIVATE vlogstb)
 target_link_libraries(vlog PUBLIC pthread)
 
 if(${ENABLE_BACKTRACE})
+  find_package(LibElf REQUIRED)
+  find_package(LibDwarf REQUIRED)
+
   target_compile_definitions(vlog PRIVATE ENABLE_BACKTRACE=1)
-  target_sources(vlog PRIVATE src/callstack.cpp)
-
-  find_path(DWARF_INCLUDE_DIR NAMES libdwarf.h dwarf.h
-            PATHS /usr/include /usr/include/libdwarf /usr/local/include /usr/local/include/libdwarf
-                  /opt/local/include ENV CPATH)
-
   target_compile_definitions(vlog PRIVATE -DBACKWARD_HAS_DWARF=1)
-  target_include_directories(vlog SYSTEM PRIVATE ${DWARF_INCLUDE_DIR})
-  target_link_libraries(vlog PRIVATE dl elf dwarf stdc++fs)
+
+  target_sources(vlog PRIVATE src/callstack.cpp)
+  target_link_libraries(vlog PRIVATE dl ${LIBELF_LIBRARIES} ${LIBDWARF_LIBRARIES})
 
   add_library(backward INTERFACE)
   target_include_directories(backward INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+else()
+  target_compile_definitions(vlog PRIVATE ENABLE_BACKTRACE=0)
 endif()
 
 if(${ENABLE_VLOG_TESTS} OR ${VLOG_MAIN_PROJECT})
   enable_testing()
-  # add_unit_test(test_lint ${VLOG_ROOT_DIR}/scripts/lint.py)
   add_subdirectory(tests)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,10 @@ endif()
 add_library(vlog SHARED src/vlog.cpp)
 target_include_directories(vlog PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(vlog PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
-if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
+if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   target_compile_options(vlog PRIVATE -pedantic -Werror -Wall -Wextra -Wno-stringop-truncation)
-else ()
-  target_compile_options(vlog PRIVATE  -Weverything -Werror -Wall -Wextra  -Werror=return-type
+elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+  target_compile_options(vlog PRIVATE -Weverything -Werror -Wall -Wextra -Werror=return-type
           -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-ctad-maybe-unsupported
           -Wno-missing-noreturn -Wno-global-constructors -Wno-reserved-id-macro)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,6 @@ option(ENABLE_VLOG_TESTS "Enable VLog Tests" ON)
 
 set(VLOG_ROOT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 
-if(${CMAKE_SYSTEM_PROCESSOR} MATCHES "x86_64")
-  add_compile_options(-march=x86-64-v3)
-else()
-  add_compile_options(-mcpu=native)
-endif()
-
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -66,6 +60,7 @@ target_link_libraries(vlog PRIVATE vlogstb)
 target_link_libraries(vlog PUBLIC pthread)
 
 if(${ENABLE_BACKTRACE})
+  message("Enabling backtrace trace")
   find_package(LibElf REQUIRED)
   find_package(LibDwarf REQUIRED)
 
@@ -73,11 +68,13 @@ if(${ENABLE_BACKTRACE})
   target_compile_definitions(vlog PRIVATE -DBACKWARD_HAS_DWARF=1)
 
   target_sources(vlog PRIVATE src/callstack.cpp)
+  target_include_directories(vlog PRIVATE ${LIBELF_INCLUDE_DIRS} ${LIBDWARF_INCLUDE_DIRS})
   target_link_libraries(vlog PRIVATE dl ${LIBELF_LIBRARIES} ${LIBDWARF_LIBRARIES})
 
   add_library(backward INTERFACE)
   target_include_directories(backward INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 else()
+  message("Disabling backtrace trace")
   target_compile_definitions(vlog PRIVATE ENABLE_BACKTRACE=0)
 endif()
 

--- a/cmake_modules/FetchDependency.cmake
+++ b/cmake_modules/FetchDependency.cmake
@@ -34,7 +34,7 @@ macro(fetch_dependency target url tag)
         add_subdirectory(${${target}_SOURCE_DIR} ${${target}_BINARY_DIR})
       endif()
       message(
-        "${BoldRed} -- ${PROJECT_SOURCE_DIR} -- ${CMAKE_CURRENT_LIST_FILE} Using ${target} downloaded from git, saved at: ${${target}_SOURCE_DIR}${ColourReset}"
+        "${BoldGreen} -- ${PROJECT_SOURCE_DIR} -- ${CMAKE_CURRENT_LIST_FILE} Using ${target} downloaded from git, saved at: ${${target}_SOURCE_DIR}${ColourReset}"
       )
     else()
       get_filename_component(dir ${${target}_project} DIRECTORY)

--- a/cmake_modules/FindLibDwarf.cmake
+++ b/cmake_modules/FindLibDwarf.cmake
@@ -1,0 +1,128 @@
+# Copyright (c) 2004-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the MIT license.
+
+# - Try to find libdwarf
+# Once done this will define
+#
+#  LIBDWARF_FOUND - system has libdwarf
+#  LIBDWARF_INCLUDE_DIRS - the libdwarf include directory
+#  LIBDWARF_LIBRARIES - Link these to use libdwarf
+#  LIBDWARF_DEFINITIONS - Compiler switches required for using libdwarf
+#
+
+# Locate libelf library at first
+if (NOT LIBELF_FOUND)
+  find_package (LibElf)
+endif (NOT LIBELF_FOUND)
+
+if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
+  set (LibDwarf_FIND_QUIETLY TRUE)
+endif (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
+
+find_package(PkgConfig)
+pkg_check_modules(PkgConfig_LibDwarf QUIET libdwarf)
+
+find_path (DWARF_INCLUDE_DIR
+  NAMES
+    libdwarf.h dwarf.h
+  PATHS
+    ${PkgConfig_LibDwarf_INCLUDE_DIRS}
+    /usr/include
+    /usr/include/libdwarf
+    /usr/local/include
+    /usr/local/include/libdwarf
+    /opt/local/include
+    /sw/include
+    ENV CPATH) # PATH and INCLUDE will also work
+
+if (DWARF_INCLUDE_DIR)
+  set (LIBDWARF_INCLUDE_DIRS  ${DWARF_INCLUDE_DIR})
+endif ()
+
+find_library (LIBDWARF_LIBRARIES
+  NAMES
+    dwarf libdwarf
+  PATHS
+    /usr/lib
+    /usr/local/lib
+    /opt/local/lib
+    /sw/lib
+    ${PkgConfig_LibDwarf_LIBRARY_DIRS}
+    ENV LIBRARY_PATH   # PATH and LIB will also work
+    ENV LD_LIBRARY_PATH)
+include (FindPackageHandleStandardArgs)
+
+
+# handle the QUIETLY and REQUIRED arguments and set LIBDWARF_FOUND to TRUE
+# if all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibDwarf DEFAULT_MSG
+  LIBELF_FOUND
+  LIBDWARF_LIBRARIES
+  LIBDWARF_INCLUDE_DIRS)
+
+if (LIBDWARF_LIBRARIES AND LIBDWARF_INCLUDE_DIRS)
+  set(CMAKE_REQUIRED_INCLUDES ${LIBDWARF_INCLUDE_DIRS})
+  set(CMAKE_REQUIRED_LIBRARIES ${LIBDWARF_LIBRARIES} ${LIBELF_LIBRARIES})
+
+  # libdwarf makes breaking changes occasionally and doesn't provide an easy
+  # way to test for them. The following checks should detect the changes and
+  # pass that information on accordingly.
+  INCLUDE(CheckCXXSourceCompiles)
+  INCLUDE(CheckFunctionExists)
+
+  MACRO(CHECK_LIBDWARF_INIT init params var)
+    # Check for the existence of this particular init function.
+    unset(INIT_EXISTS CACHE)
+    CHECK_FUNCTION_EXISTS(${init} INIT_EXISTS)
+    if (INIT_EXISTS)
+      set(LIBDWARF_USE_INIT_C ${var})
+
+      # Check to see if we can use a const name.
+      unset(DW_CONST CACHE)
+
+      if (NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+        # -std=c++11 is already set in HPHPCompiler.cmake, don't
+        # add -std=c++0x on top of that or clang will give errors
+        set(CMAKE_REQUIRED_FLAGS "-std=c++0x")
+      endif()
+
+      CHECK_CXX_SOURCE_COMPILES("
+      #include <libdwarf.h>
+      #include <cstddef>
+      int dwarfCallback(const char * a, int b, Dwarf_Unsigned c,
+        Dwarf_Unsigned d, Dwarf_Unsigned e, Dwarf_Unsigned f,
+        Dwarf_Unsigned * g, Dwarf_Ptr h, int * i) {}
+      int main() { ${init}(${params}); return 0; }" DW_CONST)
+      if (DW_CONST)
+        set(LIBDWARF_CONST_NAME 1)
+      else()
+        set(LIBDWARF_CONST_NAME 0)
+      endif()
+    endif()
+  ENDMACRO(CHECK_LIBDWARF_INIT)
+
+  # Order is important, last one is used.
+  CHECK_LIBDWARF_INIT("dwarf_producer_init"
+	"0, dwarfCallback, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr" 0)
+  CHECK_LIBDWARF_INIT("dwarf_producer_init_c" "0, dwarfCallback, nullptr, nullptr, nullptr, nullptr" 1)
+
+  set(CMAKE_REQUIRED_INCLUDES)
+  set(CMAKE_REQUIRED_LIBRARIES)
+endif()
+
+if(LIBDWARF_CONST_NAME)
+  message(STATUS "libdwarf uses const char* type")
+else()
+  message(STATUS "libdwarf uses char* type")
+endif()
+if(LIBDWARF_USE_INIT_C)
+  message(STATUS "libdwarf has dwarf_producer_init_c")
+else()
+  message(STATUS "libdwarf does not have dwarf_producer_init_c, using dwarf_producer_init")
+endif()
+
+mark_as_advanced(LIBDW_INCLUDE_DIR DWARF_INCLUDE_DIR)
+mark_as_advanced(LIBDWARF_INCLUDE_DIRS LIBDWARF_LIBRARIES)
+mark_as_advanced(LIBDWARF_CONST_NAME LIBDWARF_USE_INIT_C)

--- a/cmake_modules/FindLibElf.cmake
+++ b/cmake_modules/FindLibElf.cmake
@@ -1,0 +1,68 @@
+# - Try to find libelf
+# Once done this will define
+#
+#  LIBELF_FOUND - system has libelf
+#  LIBELF_INCLUDE_DIRS - the libelf include directory
+#  LIBELF_LIBRARIES - Link these to use libelf
+#  LIBELF_DEFINITIONS - Compiler switches required for using libelf
+#
+#  Copyright (c) 2008 Bernhard Walle <bernhard.walle@gmx.de>
+#
+#  Redistribution and use is allowed according to the terms of the New
+#  BSD license.
+
+
+if (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
+  set (LibElf_FIND_QUIETLY TRUE)
+endif (LIBELF_LIBRARIES AND LIBELF_INCLUDE_DIRS)
+
+find_package(PkgConfig)
+pkg_check_modules(PkgConfig_LibElf QUIET libelf)
+
+find_path (LIBELF_INCLUDE_DIRS
+  NAMES
+    libelf.h
+  PATHS
+    ${PkgConfig_LibElf_INCLUDE_DIRS}
+    /usr/include
+    /usr/include/libelf
+    /usr/local/include
+    /usr/local/include/libelf
+    /opt/local/include
+    /opt/local/include/libelf
+    /sw/include
+    /sw/include/libelf
+    ENV CPATH)
+
+find_library (LIBELF_LIBRARIES
+  NAMES
+    elf
+  PATHS
+    /usr/lib
+    /usr/local/lib
+    /opt/local/lib
+    /sw/lib
+    ${PkgConfig_LibElf_LIBRARY_DIRS}
+    ENV LIBRARY_PATH
+    ENV LD_LIBRARY_PATH)
+
+include (FindPackageHandleStandardArgs)
+
+
+# handle the QUIETLY and REQUIRED arguments and set LIBELF_FOUND to TRUE if all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibElf DEFAULT_MSG
+  LIBELF_LIBRARIES
+  LIBELF_INCLUDE_DIRS)
+
+SET(CMAKE_REQUIRED_LIBRARIES elf)
+INCLUDE(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("#include <libelf.h>
+int main() {
+  Elf *e = (Elf*)0;
+  size_t sz;
+  elf_getshdrstrndx(e, &sz);
+  return 0;
+}" ELF_GETSHDRSTRNDX)
+SET(CMAKE_REQUIRED_LIBRARIES)
+
+mark_as_advanced(LIBELF_INCLUDE_DIRS LIBELF_LIBRARIES ELF_GETSHDRSTRNDX)

--- a/include/backward/backward.h
+++ b/include/backward/backward.h
@@ -3857,7 +3857,9 @@ public:
     }
 
     std::set_terminate(&terminator);
+#if __cplusplus < 201703L
     std::set_unexpected(&terminator);
+#endif
 
     _loaded = success;
   }

--- a/include/backward/backward.h
+++ b/include/backward/backward.h
@@ -3877,8 +3877,6 @@ public:
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.gregs[REG_EIP]);
 #elif defined(__arm__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.arm_pc);
-#elif defined(__aarch64__)
-    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
 #elif defined(__mips__)
     error_addr = reinterpret_cast<void *>(reinterpret_cast<struct sigcontext*>(&uctx->uc_mcontext)->sc_pc);
 #elif defined(__ppc__) || defined(__powerpc) || defined(__powerpc__) ||        \
@@ -3889,7 +3887,9 @@ public:
 #elif defined(__APPLE__) && defined(__x86_64__)
     error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__rip);
 #elif defined(__APPLE__)
-    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__eip);
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext->__ss.__pc);
+#elif defined(__aarch64__)
+    error_addr = reinterpret_cast<void *>(uctx->uc_mcontext.pc);
 #else
 #warning ":/ sorry, ain't know no nothing none not of your architecture!"
 #endif

--- a/include/vlog.h
+++ b/include/vlog.h
@@ -109,8 +109,16 @@ void set_sim_time(double t);
 bool is_sim_time();
 double time_now();
 
+#ifdef _MSC_VER
+// No equivalent in MSVC for printf-style checks, so we leave it empty
+#define PRINTF_ATTRIBUTE(a, b)
+#else
+// For GCC and Clang
+#define PRINTF_ATTRIBUTE(a, b) __attribute__((format(printf, a, b)))
+#endif
+
 void vlog_func(int level, const char* category, bool newline, const char* file, int line, const char* func,
-               const char* fmt, ...) __attribute__((format(printf, 7, 8)));
+               const char* fmt, ...) PRINTF_ATTRIBUTE(7, 8);
 
 #define likely(x) __builtin_expect(!!(x), 1)
 #define unlikely(x) __builtin_expect(!!(x), 0)
@@ -215,5 +223,9 @@ const char* getOptionCategory();
 void setOptionCategory(const char* cat);
 
 std::string FormatString(const char* fmt, ...);
+
+#ifdef _WIN32
+typedef int pid_t;
+#endif
 
 pid_t GetThreadId();

--- a/src/vlog.cpp
+++ b/src/vlog.cpp
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 #include <atomic>
 #include <mutex>

--- a/src/vlog.cpp
+++ b/src/vlog.cpp
@@ -3,8 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/time.h>
-#include <sys/types.h>
 #include <unistd.h>
 
 #include <atomic>

--- a/src/vlog.cpp
+++ b/src/vlog.cpp
@@ -24,6 +24,11 @@ namespace fs = std::filesystem;
 namespace fs = std::experimental::filesystem;
 #endif
 
+#ifdef __APPLE__
+#include <crt_externs.h>
+static char **environ = *_NSGetEnviron();
+#endif
+
 static double time_sim_start = -1;
 static double time_sim_ratio = 1;
 static double time_real_start = -1;

--- a/src/vlog.cpp
+++ b/src/vlog.cpp
@@ -403,9 +403,15 @@ void vlog_fini() {
 
 #ifdef __EMSCRIPTEN__
 pid_t GetThreadId() { return 0; }
-#else
-#ifdef SYS_gettid
+#elif defined(SYS_gettid) && !defined(__APPLE__)
 pid_t GetThreadId() { return pid_t(syscall(SYS_gettid)); }
+#elif defined(__APPLE__)
+#include <pthread.h>
+pid_t GetThreadId() {
+    uint64_t tid64;
+    pthread_threadid_np(nullptr, &tid64);
+    return static_cast<pid_t>(tid64);
+}
 #else
 #error "SYS_gettid unavailable on this system"
 #endif

--- a/src/vlog.cpp
+++ b/src/vlog.cpp
@@ -5,25 +5,19 @@
 #include <string.h>
 
 #include <atomic>
+#include <filesystem>
 #include <mutex>
 #include <vector>
 
 #define STB_SPRINTF_DECORATE(name) vlstbsp_##name
 #include <stb/stb_sprintf.h>
 
-#if (defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE > 7)) || \
-    (defined(_LIBCPP_VERSION) && (_LIBCPP_VERSION > 10000))
-#include <filesystem>
-namespace fs = std::filesystem;
-#else
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-#endif
-
 #ifdef __APPLE__
 #include <crt_externs.h>
 static char **environ = *_NSGetEnviron();
 #endif
+
+namespace fs = std::filesystem;
 
 static double time_sim_start = -1;
 static double time_sim_ratio = 1;

--- a/src/vlog.cpp
+++ b/src/vlog.cpp
@@ -3,7 +3,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/syscall.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -410,6 +409,7 @@ void vlog_fini() {
 #ifdef __EMSCRIPTEN__
 pid_t GetThreadId() { return 0; }
 #elif defined(SYS_gettid) && !defined(__APPLE__)
+#include <sys/syscall.h>
 pid_t GetThreadId() { return pid_t(syscall(SYS_gettid)); }
 #elif defined(__APPLE__)
 #include <pthread.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,10 @@ macro(add_vlog_test test_name test_cpp)
       -Wno-global-constructors \
       -Wno-double-promotion \
       -Wno-padded")
-  target_link_libraries(${test_name} PUBLIC vlog gtest backward)
+  target_link_libraries(${test_name} PUBLIC vlog gtest)
+  if(${ENABLE_BACKTRACE})
+    target_link_libraries(${test_name} PUBLIC backward)
+  endif()
   if (COMMAND add_unit_test)
     add_unit_test(${test_name} ${test_name})
   else()

--- a/tests/test_vlog.cpp
+++ b/tests/test_vlog.cpp
@@ -95,8 +95,12 @@ TEST(TestVLog, NonFatalLevels) {
   EXPECT_TRUE(Contains(testing::internal::GetCapturedStdout(), TOKEN));
 
   // Test that vlog is able to truncate
+  testing::internal::CaptureStdout();
   std::string long_string(128 * 1024, 'A');
   vlog_info(VCAT_GENERAL, "%s", long_string.c_str());
+  const std::string longOutput = testing::internal::GetCapturedStdout();
+  EXPECT_TRUE(Contains(longOutput, "AAAA"));
+  EXPECT_EQ(longOutput.length(), 8191);
 }
 
 TEST(TestVLog, TestCallbacks) {

--- a/tests/test_vlog_fatals.cpp
+++ b/tests/test_vlog_fatals.cpp
@@ -12,10 +12,12 @@ static bool HaveDebugSymbols() {
   // Force the assumption of debug symbols for debug builds. This will induce a
   // test failure if they are not present in a debug build for whatever reason
   return true;
-#else
+#elif ENABLE_BACKWARD
   std::ostringstream out;
   PrintCurrentCallstack(out, false, nullptr, 0);
   return Contains(out.str(), "test_vlog_fatals.cpp");
+#else
+  return false;
 #endif
 }
 
@@ -54,14 +56,15 @@ TEST(TestVLog, Fatal) {
     if (!Contains(crash, "vlog_fatal(VCAT_GENERAL")) {
       std::cout << "Captured Output:\n" << crash << '\n';
     }
-
   } else {
+#if ENABLE_BACKWARD
     std::cout << "No debug symbols present\n";
     EXPECT_TRUE(Contains(crash, "tests/test_vlog_fatals"));
 
     if (!Contains(crash, "tests/test_vlog_fatals")) {
       std::cout << "Captured Output:\n" << crash << '\n';
     }
+#endif
   }
 }
 


### PR DESCRIPTION
* Fix tests when ENABLE_BACKWARD=0
* Skip std::set_unexpected() for C++17 and later
* Fix backward.h build failure for MacOS arm64
* Fix discovery of libdwarf and libelf, disable backtrace printing on non-Linux
* Fix environ usage on MacOS
* Fix GetThreadId() on MacOS
* Fix exit-time destructor compilation error
* Fix unit test spew and missing assertions
* Fix log message coloring when fetching gtest
* Add CI for Linux and MacOS (Windows CI will require more fixes)